### PR TITLE
Add a config item external_hostname

### DIFF
--- a/lib/TestDbServer/Configuration.pm
+++ b/lib/TestDbServer/Configuration.pm
@@ -10,6 +10,7 @@ has db_password         => ( is => 'rw' );
 has db_host             => ( is => 'rw' );
 has db_port             => ( is => 'rw' );
 has test_db_owner       => ( is => 'rw' );
+has external_hostname   => ( is => 'rw' );
 
 sub new_from_app_config {
     my($class, $config) = @_;

--- a/lib/TestDbServer/DatabaseRoutes.pm
+++ b/lib/TestDbServer/DatabaseRoutes.pm
@@ -115,7 +115,9 @@ sub _hashref_for_database_obj {
     my %h;
     @h{'id','name','owner','created','expires','template_id'}
         = map { $database->$_ } qw( database_id name owner create_time expire_time template_id );
-    @h{'host','port'} = $self->app->host_and_port_for_created_database();
+
+    $h{host} = $self->app->configuration->external_hostname;
+    $h{port} = $self->app->configuration->db_port;
 
     return \%h;
 }

--- a/test_db_server.testing.conf
+++ b/test_db_server.testing.conf
@@ -5,4 +5,5 @@
     db_port => 5432,
     db_host => 'localhost',
     test_db_owner => 'genome',
+    external_hostname => 'localhost',
 }


### PR DESCRIPTION
This is the reported DB hostname when listing database entities through
the REST interface.

This way, db_host can be set to localhost, and it can report the created
database's host as something reachable from the network

This will resolve #41 
