### PR TITLE
When expiring databases, remove the record even if no database exists on...

### DIFF
--- a/lib/TestDbServer/DatabaseRoutes.pm
+++ b/lib/TestDbServer/DatabaseRoutes.pm
@@ -105,6 +105,12 @@ sub _remove_expired_databases {
         }
         catch {
             $self->app->log->error("expire database ".$database->database_id." failed: $_");
+            if (ref($_) && $_->isa('Exception::CannotDropDatabase')) {
+                $self->app->log->info('  removing database record');
+                $schema->txn_do(sub {
+                    $database->delete();
+                });
+            }
         };
     }
 }


### PR DESCRIPTION
... the server

Tests were running slowly and the log indicated there were a bunch of
live_database records it was trying to expire, but there were no corresponding
databases on the Postgres server.  Maybe leftovers from testing.

This change catches the particular exception and goes ahead and removes
the record of this missing database.
