### PR TITLE
use Travis CI's newer, more reliable infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 addons:
   postgresql: "9.3"
 language: perl


### PR DESCRIPTION
[Faster Builds with Container-Based Infrastructure and Docker](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/) says
to add `sudo: false` to try new infrastructure.  Claims tests will start
running in seconds instead of minutes and have fewer infrastructure
related failures.
