### PR TITLE
Default template name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ perl:
 env: TEST_DB_CONF=test_db_server.travis-ci.conf PGUSER=postgres
 before_script:
   - make clean
+  - createdb -T template1 template2
 script: prove -lvr t/

--- a/lib/TestDbServer/Command/CreateDatabaseFromTemplate.pm
+++ b/lib/TestDbServer/Command/CreateDatabaseFromTemplate.pm
@@ -25,6 +25,7 @@ sub execute {
 
     my $owner = $self->owner || $template->owner;
     my $pg = TestDbServer::PostgresInstance->new(
+                        connect_db_name => $template_name,
                         host => $self->host,
                         port => $self->port,
                         owner => $owner,

--- a/lib/TestDbServer/Command/CreateTemplateFromDatabase.pm
+++ b/lib/TestDbServer/Command/CreateTemplateFromDatabase.pm
@@ -22,6 +22,7 @@ sub execute {
     }
 
     my $pg = TestDbServer::PostgresInstance->new(
+                    connect_db_name => $database->name,
                     host => $self->host,
                     port => $self->port,
                     owner => $database->owner,

--- a/lib/TestDbServer/Command/DeleteTemplateOrDatabase.pm
+++ b/lib/TestDbServer/Command/DeleteTemplateOrDatabase.pm
@@ -10,6 +10,7 @@ has schema => (isa => 'TestDbServer::Schema', is => 'ro', required => 1 );
 has superuser => ( isa => 'Str', is => 'ro', required => 1 );
 has host => ( isa => 'Str', is => 'ro', required => 1 );
 has port => ( isa => 'Str', is => 'ro', required => 1 );
+has connect_db_name => ( isa => 'Str', is => 'ro', required => 1 );
 
 foreach my $subname ( qw( _entity_find_method _entity_id_method _not_found_exception )) {
     no strict 'refs';
@@ -28,7 +29,7 @@ sub execute {
     }
 
     my $pg = TestDbServer::PostgresInstance->new(
-                        name => $entity->name,
+                        connect_db_name => $entity->name,
                         host => $self->host,
                         port => $self->port,
                         owner => $entity->owner,

--- a/lib/TestDbServer/DatabaseRoutes.pm
+++ b/lib/TestDbServer/DatabaseRoutes.pm
@@ -99,6 +99,7 @@ sub _remove_expired_databases {
                                 superuser => $self->app->configuration->db_user,
                                 host => $host,
                                 port => $port,
+                                connect_db_name => $self->app->configuration->default_template_name,
                             );
                 $cmd->execute();
             });
@@ -201,6 +202,7 @@ sub delete {
                         superuser => $self->app->configuration->db_user,
                         host => $host,
                         port => $port,
+                        connect_db_name => $self->app->configuration->default_template_name,
                     );
         $schema->txn_do(sub {
             $cmd->execute();

--- a/lib/TestDbServer/PostgresInstance.pm
+++ b/lib/TestDbServer/PostgresInstance.pm
@@ -25,6 +25,11 @@ has 'port' => (
     isa => 'Int',
     required => 1,
 );
+has 'connect_db_name' => (
+    is => 'ro',
+    isa => 'Str',
+    required => 1,
+);
 has 'owner' => (
     is => 'ro',
     isa => 'pg_identifier',
@@ -53,8 +58,8 @@ has '_admin_dbh' => (
 
 sub _build_admin_dbh {
     my $self = shift;
-    my($host, $port, $user, $pass) = map { $self->$_ } ( 'host', 'port', 'superuser', 'superuser_passwd' );
-    return DBI->connect_cached("dbi:Pg:dbname=template1;port=$port;host=$host",
+    my($host, $port, $name, $user, $pass) = map { $self->$_ } ( 'host', 'port', 'connect_db_name', 'superuser', 'superuser_passwd' );
+    return DBI->connect_cached("dbi:Pg:dbname=$name;port=$port;host=$host",
                                $user, $pass,
                                { RaiseError => 1, PrintError => 0 });
 }

--- a/lib/TestDbServer/TemplateRoutes.pm
+++ b/lib/TestDbServer/TemplateRoutes.pm
@@ -158,6 +158,7 @@ sub delete {
                     superuser => $self->app->configuration->db_user,
                     host => $host,
                     port => $port,
+                    connect_db_name => $self->app->configuration->default_template_name,
                 );
         $schema->txn_do(sub {
             $cmd->execute();

--- a/t/commands.t
+++ b/t/commands.t
@@ -68,6 +68,7 @@ subtest 'create template from database' => sub {
 
     # remove the template database
     TestDbServer::PostgresInstance->new(
+                        connect_db_name => $config->default_template_name,
                         host => $pg->host,
                         port => $pg->port,
                         owner => $template->owner,
@@ -118,6 +119,7 @@ subtest 'create database with owner' => sub {
 
     # remove the created database
     TestDbServer::PostgresInstance->new(
+                        connect_db_name => $config->default_template_name,
                         host => $config->db_host,
                         port => $config->db_port,
                         owner => $database->owner,
@@ -198,6 +200,7 @@ subtest 'create database from template' => sub {
 
     # remove the created database
     TestDbServer::PostgresInstance->new(
+                        connect_db_name => $config->default_template_name,
                         host => $config->db_host,
                         port => $config->db_port,
                         owner => $database->owner,
@@ -300,6 +303,7 @@ subtest 'delete with connections' => sub {
 
 sub new_pg_instance {
     my $pg = TestDbServer::PostgresInstance->new(
+            connect_db_name => $config->default_template_name,
             host => $config->db_host,
             port => $config->db_port,
             owner => $config->test_db_owner,

--- a/t/commands.t
+++ b/t/commands.t
@@ -309,7 +309,7 @@ sub new_pg_instance {
             owner => $config->test_db_owner,
             superuser => $config->db_user,
         );
-    $pg->createdb_from_template('template1');
+    $pg->createdb_from_template($config->default_template_name);
     return $pg;
 }
 

--- a/t/database.t
+++ b/t/database.t
@@ -92,12 +92,13 @@ subtest 'create from template' => sub {
 
     my $db = $app->db_storage();
     my $pg = TestDbServer::PostgresInstance->new(
+                    connect_db_name => $config->default_template_name,
                     host => $config->db_host,
                     port => $config->db_port,
                     owner => $config->test_db_owner,
                     superuser => $config->db_user,
                 );
-    ok( $pg->createdb_from_template('template1'), 'create database to use as a template');
+    ok( $pg->createdb_from_template($config->default_template_name), 'create database to use as a template');
 
     my $template = $db->create_template(
                                             name => $pg->name,

--- a/t/postgres-instance.t
+++ b/t/postgres-instance.t
@@ -47,7 +47,7 @@ subtest 'create connect delete' => sub {
     ok($pg, 'Created new PostgresInstance');
     ok($pg->name, 'has a name: '. $pg->name);
 
-    ok($pg->createdb_from_template('template1'), 'Create database');
+    ok($pg->createdb_from_template($config->default_template_name), 'Create database');
 
     my $db_name = $pg->name;
     ok(connect_to_db($db_name), 'Connected');
@@ -60,7 +60,7 @@ subtest 'create db from template' => sub {
     plan tests => 5;
 
     my $original_pg = create_pg_object_from_config();
-    ok($original_pg->createdb_from_template('template1'), 'Create original DB');
+    ok($original_pg->createdb_from_template($config->default_template_name), 'Create original DB');
     {
         my $dbi = DBI->connect(sprintf('dbi:Pg:dbname=%s;host=%s;port=%s',
                                         $original_pg->name, $original_pg->host, $original_pg->port),
@@ -89,7 +89,7 @@ subtest 'create duplicate database' => sub {
     plan tests => 2;
 
     my $original_pg = create_pg_object_from_config();
-    ok($original_pg->createdb_from_template('template1'), 'Create original DB');
+    ok($original_pg->createdb_from_template($config->default_template_name), 'Create original DB');
 
     my $copy_pg = TestDbServer::PostgresInstance->new(
                 connect_db_name => $connect_db_name,
@@ -99,7 +99,7 @@ subtest 'create duplicate database' => sub {
                 superuser => $superuser,
                 name => $original_pg->name,
             );
-    throws_ok { $copy_pg->createdb_from_template('template1') }
+    throws_ok { $copy_pg->createdb_from_template($config->default_template_name) }
             'Exception::CannotCreateDatabase',
             'Creating a database with duplicate name throws exception';
 };
@@ -118,7 +118,7 @@ subtest 'is_valid_database' => sub {
     my $pg = create_pg_object_from_config();
     ok(! $pg->is_valid_database($pg->name), 'database does not exist yet');
 
-    ok($pg->createdb_from_template('template1'), 'create database');
+    ok($pg->createdb_from_template($config->default_template_name), 'create database');
     ok($pg->is_valid_database($pg->name), 'database exists now');
 
     ok($pg->dropdb, 'delete database');

--- a/t/postgres-instance.t
+++ b/t/postgres-instance.t
@@ -18,13 +18,14 @@ my $host = $config->db_host;
 my $port = $config->db_port;
 my $superuser = $config->db_user;
 my $owner = $config->test_db_owner;
+my $connect_db_name = $config->default_template_name;
 
 subtest 'create from template param validation' => sub {
-    plan tests => 3;
+    plan tests => 4;
 
     my $invalid_sql = q{'Robert'); DROP TABLE students; --};
-    my %valid_params = ( host => $host, port => $port, owner => $owner, superuser => $superuser );
-    foreach my $check_param ( qw( name owner ) ) {
+    my %valid_params = ( host => $host, port => $port, owner => $owner, superuser => $superuser, connect_db_name => $connect_db_name );
+    foreach my $check_param ( qw( name owner connect_db_name ) ) {
         throws_ok { TestDbServer::PostgresInstance->new(
                         %valid_params,
                         $check_param => $invalid_sql,
@@ -91,6 +92,7 @@ subtest 'create duplicate database' => sub {
     ok($original_pg->createdb_from_template('template1'), 'Create original DB');
 
     my $copy_pg = TestDbServer::PostgresInstance->new(
+                connect_db_name => $connect_db_name,
                 host => $host,
                 port => $port,
                 owner => $owner,
@@ -130,6 +132,7 @@ sub connect_to_db {
 
 sub create_pg_object_from_config {
     return TestDbServer::PostgresInstance->new(
+                connect_db_name => $connect_db_name,
                 host => $host,
                 port => $port,
                 owner => $owner,

--- a/test_db_server.travis-ci.conf
+++ b/test_db_server.travis-ci.conf
@@ -5,6 +5,6 @@
     db_port => 5432,
     db_host => 'localhost',
     test_db_owner => 'genome',
-    default_template_name => 'template1',
+    default_template_name => 'template2',
     external_hostname => 'localhost',
 }


### PR DESCRIPTION
The PostgresInstance class has a new attribute to specify which template DB to connect to for issuing commands to the database.  It used to be hard-coded to 'template1'.

The TravisCI config is also changed to make a new template DB called 'template2' and use it as the default template.