### PR TITLE
connect() instead of connect_cached() for template1

### DIFF
--- a/lib/TestDbServer/PostgresInstance.pm
+++ b/lib/TestDbServer/PostgresInstance.pm
@@ -54,7 +54,7 @@ has '_admin_dbh' => (
 sub _build_admin_dbh {
     my $self = shift;
     my($host, $port, $user, $pass) = map { $self->$_ } ( 'host', 'port', 'superuser', 'superuser_passwd' );
-    return DBI->connect_cached("dbi:Pg:dbname=template1;port=$port;host=$host",
+    return DBI->connect("dbi:Pg:dbname=template1;port=$port;host=$host",
                                $user, $pass,
                                { RaiseError => 1, PrintError => 0 });
 }


### PR DESCRIPTION
Keeping an idle connection to template1 was messing up our monitoring system.
This way the connection to template1 should only exist as long as we're
creating or dropping a database.