### PR TITLE
Print help if no type specified to delete.

### DIFF
--- a/bin/test-db-delete
+++ b/bin/test-db-delete
@@ -12,6 +12,8 @@ print_short_help() if ($opts->{'short-help'});
 print_help() if ($opts->{help});
 
 my $type = shift @ARGV;
+print_help() unless defined $type;
+
 if ($type ne 'database' and $type ne 'template') {
     print STDERR "Cannot delete a $type\n";
     exit 1;

--- a/cpanfile
+++ b/cpanfile
@@ -7,6 +7,7 @@ requires 'DBD::Pg';
 requires 'DBI', '1.63';
 requires 'DBIx::Class';
 requires 'Exception::Class';
+requires 'JSON';
 requires 'Mojolicious', '5';
 requires 'Moose', '2.1';
 requires 'MooseX::NonMoose';


### PR DESCRIPTION
As part of looking at genome/genome#509 I ran `test-db delete` with no arguments and got:
```
$ test-db delete
Use of uninitialized value $type in string ne at /usr/bin/test-db-delete line 15.
Use of uninitialized value $type in string ne at /usr/bin/test-db-delete line 15.
Use of uninitialized value $type in concatenation (.) or string at /usr/bin/test-db-delete line 16.
Cannot delete a 
```

This prints the help instead if no argument was supplied.