### PR TITLE
Some more error checking, and exit 1 when help displayed due to missing arguments.

### DIFF
--- a/bin/test-db
+++ b/bin/test-db
@@ -52,6 +52,8 @@ sub show_help {
     foreach my $help ( @help ) {
         printf("%-${max_width}s %s\n", @$help);
     }
+
+    exit(1);
 }
 
 sub alter_perl5lib_for_testdbserver_libs {

--- a/bin/test-db-delete
+++ b/bin/test-db-delete
@@ -12,7 +12,7 @@ print_short_help() if ($opts->{'short-help'});
 print_help() if ($opts->{help});
 
 my $type = shift @ARGV;
-print_help() unless defined $type;
+print_help(1) unless defined $type;
 
 if ($type ne 'database' and $type ne 'template') {
     print STDERR "Cannot delete a $type\n";
@@ -64,11 +64,12 @@ sub print_short_help {
 }
 
 sub print_help {
+    my $exit = shift || 0;
     print <<"EOS";
 Usage: $0 template <name>
        $0 database <name>
 
 Delete a template or a database.
 EOS
-    exit;
+    exit $exit;
 }

--- a/bin/test-db-delete
+++ b/bin/test-db-delete
@@ -19,7 +19,7 @@ if ($type ne 'database' and $type ne 'template') {
     exit 1;
 }
 if (@ARGV != 1) {
-    print STDERR "Exactly one can be deleted, got ",scalar(@ARGV);
+    printf STDERR "Exactly one %s can be deleted, got %d\n",$type,scalar(@ARGV);
     exit 1;
 }
 

--- a/bin/test-db-template-create
+++ b/bin/test-db-template-create
@@ -16,6 +16,15 @@ my ($name, $db_name) = @ARGV;
 
 # validate name
 # validate db_name
+unless (defined $name) {
+    print STDERR "NAME is required\n";
+    exit 1;
+}
+
+unless (defined $db_name) {
+    print STDERR "DB_ID is required\n";
+    exit 1;
+}
 
 my $ua = get_user_agent($opts->{timeout});
 


### PR DESCRIPTION
I added some checks for name and db_id to be present in `test-db template create`.  It makes me wonder if I should have said "type is required" in `test-db delete`.  The two cases seem a little different, but the difference between a sub-command and a positional argument is rather subtle as a user.

`test-db` itself doesn't have a `--help` option, so I changed it to always exit 1... but would it be better to add a `--help` and exit 0 in that case?