### PR TITLE
Allow deleting a template which has databases made from it

### DIFF
--- a/lib/TestDbServer/Command/DeleteTemplate.pm
+++ b/lib/TestDbServer/Command/DeleteTemplate.pm
@@ -12,6 +12,15 @@ sub _entity_find_method { 'find_template' }
 sub _entity_id_method { 'template_id' }
 sub _not_found_exception { 'Exception::TemplateNotFound' }
 
+sub execute {
+    my $self = shift;
+
+    my $databases_with_this_template = $self->schema->search_database(template_id => $self->template_id);
+    $databases_with_this_template->update({template_id => undef});
+
+    $self->SUPER::execute();
+}
+
 __PACKAGE__->meta->make_immutable;
 
 1;


### PR DESCRIPTION
When deleting a template, find all the live database records which reference
this template, and set their template_id to NULL.

This fixes #59