### PR TITLE
Return 503 if the database server can't make the database

### DIFF
--- a/docs/rest-api.txt
+++ b/docs/rest-api.txt
@@ -128,6 +128,8 @@ Returns 201 and JSON in the body
 }
 The Location header will be the URL for this entity
 
+Returns 503 if the database server was not able to create the requested database
+
 -----------------------------------------------------
 
 POST /databases?based_on=<template-name>
@@ -149,6 +151,7 @@ Returns 201 and JSON in the body
 The Location header will be the URL for this entity
 
 Returns 404 if there is no template with that name
+Returns 503 if the database server was not able to create the requested database
 
 ---------------------------------------------------------
 

--- a/lib/TestDbServer/DatabaseRoutes.pm
+++ b/lib/TestDbServer/DatabaseRoutes.pm
@@ -167,7 +167,7 @@ sub create {
             $self->app->log->error('template not found');
             $return_code = 404;
 
-        } elsif ref($_) && $_->isa('Exception::CannotCreateDatabase')) {
+        } elsif (ref($_) && $_->isa('Exception::CannotCreateDatabase')) {
             $self->app->log->error("Cannot create database: $_");
             $return_code = 503;
 

--- a/lib/TestDbServer/DatabaseRoutes.pm
+++ b/lib/TestDbServer/DatabaseRoutes.pm
@@ -167,6 +167,10 @@ sub create {
             $self->app->log->error('template not found');
             $return_code = 404;
 
+        } elsif ref($_) && $_->isa('Exception::CannotCreateDatabase')) {
+            $self->app->log->error("Cannot create database: $_");
+            $return_code = 503;
+
         } else {
             $self->app->log->fatal("_create_database_from_template: $_");
             $return_code = 400;


### PR DESCRIPTION
This is intended to resolve #60, but it doesn't solve that particular problem.
It looks like the full-disk problem makes the CREATE DATABASE statement in
PostgresInstance::createdb_from_template() fail, which throws
Exception::CannotCreateDatabase.  Without parsing the test of the error
returned by the server, we can't deduce why it failed.

The test is kind if cheesy, relying on the one and only do() to be that
CREATE DATABASE statement.

We're now catching that exception and returning 503 instead of the default 400.