### PR TITLE
Change how 404s are rendered

### DIFF
--- a/lib/TestDbServer/DatabaseRoutes.pm
+++ b/lib/TestDbServer/DatabaseRoutes.pm
@@ -77,7 +77,7 @@ sub get {
 
     } else {
         $self->app->log->info("database $id not found");
-        $self->render_not_found;
+        $self->render(status => 404, text => "database $id not found");
     }
 }
 

--- a/lib/TestDbServer/TemplateRoutes.pm
+++ b/lib/TestDbServer/TemplateRoutes.pm
@@ -81,7 +81,7 @@ sub get {
 
     } else {
         $self->app->log->info("template $id not found");
-        $self->render_not_found;
+        $self->render(status => 404, text => "Template $id not found");
     }
 }
 


### PR DESCRIPTION
At some point, Mojolicious deprecated and later removed the render_not_found()
(and render_exception()) methods,  The new way is to use the "reply" helper
found in Mojolicious::Plugin::DefaultHelpers like this:
    $self->reply->not_found()

That's not available in the older version we have installed currently.

This way will work with both the old and newer versions of Mojo.